### PR TITLE
Add websocket notification endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # fastapi-notification
+
+This project provides a minimal FastAPI application exposing a websocket
+endpoint for sending and receiving notifications.
+
+## Running the server
+
+1. Install the requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application using Uvicorn:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+Connect to `ws://localhost:8000/ws/notifications` from a websocket client
+to send and receive messages.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,35 @@
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+app = FastAPI()
+
+class ConnectionManager:
+    """Manages websocket connections for notifications."""
+
+    def __init__(self) -> None:
+        self.active_connections: list[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.active_connections.append(websocket)
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
+
+    async def broadcast(self, message: str) -> None:
+        for connection in self.active_connections:
+            await connection.send_text(message)
+
+manager = ConnectionManager()
+
+@app.websocket("/ws/notifications")
+async def notifications_websocket(websocket: WebSocket) -> None:
+    """Websocket endpoint for receiving and broadcasting notifications."""
+    await manager.connect(websocket)
+    try:
+        while True:
+            data = await websocket.receive_text()
+            await manager.broadcast(data)
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)
+        await manager.broadcast("A client disconnected")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- implement minimal FastAPI app with `/ws/notifications` websocket endpoint
- document how to run the server
- add FastAPI and Uvicorn requirements

## Testing
- `pip install -r requirements.txt`
- `uvicorn app.main:app --port 8001 --reload --timeout-keep-alive 1`

------
https://chatgpt.com/codex/tasks/task_e_683ff1447a3c832a90ff7a5f85016a84