### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -16,3 +16,14 @@ endpoint for sending and receiving notifications.
 
 Connect to `ws://localhost:8000/ws/notifications` from a websocket client
 to send and receive messages.
+
+## Running with Docker
+
+1. Build the Docker image:
+   ```bash
+   docker build -t fastapi-notification .
+   ```
+2. Run the container:
+   ```bash
+   docker run -p 8000:8000 fastapi-notification
+   ```


### PR DESCRIPTION
## Summary
- add Dockerfile for containerized FastAPI server
- ignore virtual environment and bytecode in `.dockerignore`
- document how to run the app with Docker

## Testing
- `docker build -t dummy .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff4696758832abcdef39496665bad